### PR TITLE
When body is too big in the socket, not all body was readed and so, B…

### DIFF
--- a/t2ws.tcl
+++ b/t2ws.tcl
@@ -1080,7 +1080,10 @@
 
 		# Read the Body (if the header section was read successfully)
 		if {$State=="Body"} {
-			set RequestBody [read $Socket]
+		    set RequestBody {}
+		    while {![eof $Socket]} {
+			append RequestBody [read $Socket]
+		    }
 			if {$RequestBody!=""} {
 				Log {$RequestBody} input 3 }
 		}


### PR DESCRIPTION
…ody in the Request dict were incomplete.