### PR TITLE
Add args destructuring for route callback

### DIFF
--- a/t2ws.tcl
+++ b/t2ws.tcl
@@ -1212,7 +1212,7 @@
 		# Call the responder command
 		if {![dict exists $Response ErrorStatus]} {
 			Log {Call Responder command: [lindex $ResponderDef 3]} info 2
-			catch {set ResponseD [[lindex $ResponderDef 3] $Request]}
+			catch {set ResponseD [{*}[lindex $ResponderDef 3] $Request]}
 
 			# Process the response (there was a failure if 'ResponseD' doesn't exist)
 			if {[info exists ResponseD]} {


### PR DESCRIPTION
This modyfication allows to pass some arguments in the moment of creating callback for route. For example:
`t2ws::DefineRoute $server [list foo $arg1 $arg2] -method $method -uri $uri`
Without argument destructuring it is impossible to do so.